### PR TITLE
Publish documentation to GitHub Pages

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Changelog
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## Checklist
+
+- [ ] Test
+- [ ] Self-review
+- [ ] Documentation

--- a/.github/workflows/doc-release.yml
+++ b/.github/workflows/doc-release.yml
@@ -1,0 +1,50 @@
+# Copyright (c) Jiaqi Liu.
+---
+name: Documentation Release
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+
+jobs:
+  test:
+    uses: ./.github/workflows/notebooks.yml
+    secrets: inherit
+
+  deploy-documentation:
+    name: Deploy Documentation to GitHub Pages
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Install Graphviz
+      - run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz graphviz-dev
+
+      - name: Install Python dependencies
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install --upgrade wheel setuptools pip
+          pip install -r requirements.txt
+
+      - name: Build site
+        run: |
+          source venv/bin/activate
+          make -C site/ SPHINXOPTS="-nWT --keep-going" html
+
+      - name: Deploy docs to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: site/_build/html
+          user_name: QubitPi
+          user_email: jack20220723@gmail.com

--- a/.github/workflows/doc-release.yml
+++ b/.github/workflows/doc-release.yml
@@ -3,8 +3,6 @@
 name: Documentation Release
 
 on:
-  pull_request:
-    branches: [master]
   push:
     branches: [master]
 

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -4,10 +4,11 @@ on:
   workflow_call:
   push:
     branches:
-    - main
+      - main
   pull_request:
     branches:
-    - master
+      - main
+      - master
 
 jobs:
   build:

--- a/.github/workflows/notebooks.yml
+++ b/.github/workflows/notebooks.yml
@@ -1,12 +1,13 @@
 name: NetworkX Notebooks
 
 on:
+  workflow_call:
   push:
     branches:
     - main
   pull_request:
     branches:
-    - main
+    - master
 
 jobs:
   build:
@@ -34,7 +35,7 @@ jobs:
         fi
         python3 -m venv ~/venv
         source ~/venv/bin/activate
-  
+
     - name: Install dependencies
       run: |
         pip install pip==21.1.1
@@ -47,7 +48,7 @@ jobs:
         # pre-commit wants files to be staged
         git add content/
         pre-commit run --all-files --show-diff-on-failure --color always
-        
+
     - name: Test with nbval
       run: |
         pip install pytest

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .#*
 .coverage
 site/_build
+.idea/

--- a/site/conf.py
+++ b/site/conf.py
@@ -48,6 +48,8 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # -- Options for HTML output -------------------------------------------------
 
+html_baseurl = "https://QubitPi.github.io/nx-guides/"
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #


### PR DESCRIPTION
## Changelog

- Added new CI/CD by automatically running [original tests](https://github.com/QubitPi/nx-guides/blob/master/.github/workflows/notebooks.yml) and then deploying documentation to GitHub Pages on each `master` branch commit
- Added pull request template

### Changed

### Deprecated

### Removed

### Fixed

### Security

## Checklist

- [x] Test
- [x] Self-review
- [x] Documentation
